### PR TITLE
Sorting services by their name by default

### DIFF
--- a/src/dSessionBusServicesModel.cpp
+++ b/src/dSessionBusServicesModel.cpp
@@ -12,6 +12,7 @@ DSessionBusServicesModel::DSessionBusServicesModel(QObject *parent) :
     }
     foreach (QString name, reply.value())
         serviceNames << name;
+    serviceNames.sort();
 }
 
 QHash<int, QByteArray> DSessionBusServicesModel::roleNames() const {

--- a/src/dSessionBusServicesModel.h
+++ b/src/dSessionBusServicesModel.h
@@ -21,7 +21,7 @@ public:
     Q_INVOKABLE QString getServiceName(const int i);
 
 private:
-    QVector<QString> serviceNames;
+    QStringList serviceNames;
 };
 
 #endif // DSESSIONBUSSERVICESMODEL_H

--- a/src/dSystemBusServicesModel.cpp
+++ b/src/dSystemBusServicesModel.cpp
@@ -12,6 +12,7 @@ DSystemBusServicesModel::DSystemBusServicesModel(QObject *parent) :
     }
     foreach (QString name, reply.value())
         serviceNames << name;
+    serviceNames.sort();
 }
 
 QHash<int, QByteArray> DSystemBusServicesModel::roleNames() const {

--- a/src/dSystemBusServicesModel.h
+++ b/src/dSystemBusServicesModel.h
@@ -21,7 +21,7 @@ public:
     Q_INVOKABLE QString getServiceName(const int i);
 
 private:
-    QVector<QString> serviceNames;
+    QStringList serviceNames;
 };
 
 #endif // DSYSTEMBUSSERVICESMODEL_H


### PR DESCRIPTION
Hi Joerg,

I know I owe you with implementing #1 ,  but I came across some DBUS related hacking again, and found the unordered service list a bit inconvenient. By sorting the services by name it became easier to find a service. This PR implements the sorting. 